### PR TITLE
Terraform012 migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL := /bin/bash
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md
+export TERRAFORM_VERSION=0.12.19
 
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 

--- a/README.yaml
+++ b/README.yaml
@@ -41,24 +41,31 @@ related:
 
 # Short description of this project
 description: |-
-  Terraform module to provision ECS cluster with [Traefik](https://traefik.io/) as an edge router
+  Terraform module to provision ECS cluster with [Traefik](https://traefik.io/) as an edge router.
+  This module supports [traefik v1.7](https://docs.traefik.io/v1.7/).
+
+  ### Terraform versions
+
+  Terraform 0.12. Pin module version to `~> 2.0`. Submit pull-requests to `master` branch.
+
+  Terraform 0.11. Pin module version to `~> 1.0`. Submit pull-requests to `terraform011` branch.
 
 introduction: |-
   This module helps to provision production-ready ECS cluster for your workloads and all required infrastructure for the
   cluster (VPC, subnets, ALB, EC2 autoscaling group etc).
 
-  Traefik service in ECS cluster is supposed to act as an edge router and route traffic to other containers in your
-  cluster based on their docker lables.
+  Traefik service in ECS cluster is supposed to act as an [edge router](https://docs.traefik.io/v1.7/#overview)
+  and route traffic to other containers in your cluster based on their docker lables.
 
   For more information on which docker labels to set on your container, see
-  [Traefik documentation](https://docs.traefik.io/configuration/backends/docker/#on-containers).
+  [Traefik documentation](https://docs.traefik.io/v1.7/configuration/backends/docker/#on-containers).
 
   SSL termination is done on AWS ALB. Traefik tasks are launched with `awsvpc` network mode and needs
   Internet access to connect to ECS API in order to discover containers in your ECS cluster.
 
   **Implementation notes and Warnings**:
   - If you decide not to use NAT instance or NAT Gateway for private subnets withing the VPC, EC2 ASG instances will be
-    launched in public subnets within the VPC as they need internet access to communicated with ECS API. Otherwise, the
+    launched in public subnets within the VPC as they need internet access to communicate with ECS API. Otherwise, the
     instances will be launched in private subnets.
   - If you decide to launch Traefik using `FARGATE` launch type, remember to assing public IP for Traefik so the Traefik
     image can be pulled from Dockerhub.
@@ -80,23 +87,24 @@ usage: |-
     namespace = "cp"
     stage     = "prod"
 
-    vpc_nat_gateway_enabled     = "false"
-    vpc_map_public_ip_on_launch = "false"
+    vpc_nat_gateway_enabled     = false
+    vpc_map_public_ip_on_launch = false
 
     alb_certificate_arn                  = "XXXXXXXXXXX"
-    alb_http_enabled                     = "true"
-    alb_https_enabled                    = "true"
-    alb_http_to_https_redirect_enabled   = "true"
-    alb_http_to_https_redirect_permanent = "true"
-    alb_access_logs_enabled              = "false"
+    alb_http_enabled                     = true
+    alb_https_enabled                    = true
+    alb_http_to_https_redirect_enabled   = true
+    alb_http_to_https_redirect_permanent = true
+    alb_access_logs_enabled              = false
 
     traefik_launch_type      = "FARGATE"
-    traefik_assign_public_ip = "true"
+    traefik_assign_public_ip = true
   }
   ```
 
 examples: |-
-  ### Example With [Traefik Dashboard](https://docs.traefik.io/configuration/api/) and Autoscaling Enabled
+  ### Example With [Traefik Dashboard](https://docs.traefik.io/v1.7/configuration/api/#dashboard-web-ui) and
+  Autoscaling Enabled
 
   This example launches a Traefik setvice in ECS using `FARGATE` with enabled dashboard, API endpoints and autoscaling.
   Basic auth is enabled by default for both API and dashboard. You can use `openssl` to generate password for
@@ -112,34 +120,34 @@ examples: |-
     namespace = "cp"
     stage     = "prod"
 
-    vpc_nat_gateway_enabled     = "false"
-    vpc_map_public_ip_on_launch = "false"
+    vpc_nat_gateway_enabled     = false
+    vpc_map_public_ip_on_launch = false
 
     alb_certificate_arn                  = "XXXXXXXXXXX"
-    alb_http_enabled                     = "true"
-    alb_https_enabled                    = "true"
-    alb_http_to_https_redirect_enabled   = "true"
-    alb_http_to_https_redirect_permanent = "true"
-    alb_access_logs_enabled              = "false"
+    alb_http_enabled                     = true
+    alb_https_enabled                    = true
+    alb_http_to_https_redirect_enabled   = true
+    alb_http_to_https_redirect_permanent = true
+    alb_access_logs_enabled              = false
 
     traefik_launch_type      = "FARGATE"
-    traefik_assign_public_ip = "true"
+    traefik_assign_public_ip = true
 
-    traefik_dashboard_enabled             = "true"
+    traefik_dashboard_enabled             = true
     traefik_dashboard_host                = "traefik.example.com"
     traefik_dashboard_basic_auth_user     = "admin"
     traefik_dashboard_basic_auth_password = "$$$apr1$$$Rj21EpGU$$$KCwTHCbAIVhw0BiSdU4Me0"
 
-    traefik_autoscaling_enabled             = "true"
+    traefik_autoscaling_enabled             = true
     traefik_autoscaling_dimension           = "cpu"
-    traefik_autoscaling_min_capacity        = "1"
-    traefik_autoscaling_max_capacity        = "3"
-    traefik_autoscaling_scale_up_cooldown   = "60"
-    traefik_autoscaling_scale_down_cooldown = "60"
+    traefik_autoscaling_min_capacity        = 1
+    traefik_autoscaling_max_capacity        = 3
+    traefik_autoscaling_scale_up_cooldown   = 60
+    traefik_autoscaling_scale_down_cooldown = 60
 
-    traefik_ecs_alarms_enabled                        = "true"
-    traefik_ecs_alarms_cpu_utilization_high_threshold = "20"
-    traefik_ecs_alarms_cpu_utilization_low_threshold  = "10"
+    traefik_ecs_alarms_enabled                        = true
+    traefik_ecs_alarms_cpu_utilization_high_threshold = 20
+    traefik_ecs_alarms_cpu_utilization_low_threshold  = 10
   }
   ```
 
@@ -159,39 +167,39 @@ examples: |-
     namespace = "cp"
     stage     = "prod"
 
-    vpc_nat_gateway_enabled     = "false"
-    vpc_map_public_ip_on_launch = "false"
+    vpc_nat_gateway_enabled     = false
+    vpc_map_public_ip_on_launch = false
 
-    ec2_asg_enabled                  = "true"
+    ec2_asg_enabled                  = true
     ec2_asg_instance_type            = "t3.large"
-    ec2_asg_autoscaling_min_capacity = "2"
+    ec2_asg_autoscaling_min_capacity = 2
 
     alb_certificate_arn                  = "XXXXXXXXXXX"
-    alb_http_enabled                     = "true"
-    alb_https_enabled                    = "true"
-    alb_http_to_https_redirect_enabled   = "true"
-    alb_http_to_https_redirect_permanent = "true"
-    alb_access_logs_enabled              = "false"
-    alb_target_group_alarms_enabled      = "true"
+    alb_http_enabled                     = true
+    alb_https_enabled                    = true
+    alb_http_to_https_redirect_enabled   = true
+    alb_http_to_https_redirect_permanent = true
+    alb_access_logs_enabled              = false
+    alb_target_group_alarms_enabled      = true
 
     traefik_launch_type      = "FARGATE"
-    traefik_assign_public_ip = "true"
+    traefik_assign_public_ip = true
 
-    traefik_dashboard_enabled             = "true"
+    traefik_dashboard_enabled             = true
     traefik_dashboard_host                = "traefik.example.com"
     traefik_dashboard_basic_auth_user     = "admin"
     traefik_dashboard_basic_auth_password = "$$$apr1$$$Rj21EpGU$$$KCwTHCbAIVhw0BiSdU4Me0"
 
-    traefik_autoscaling_enabled             = "true"
+    traefik_autoscaling_enabled             = true
     traefik_autoscaling_dimension           = "cpu"
-    traefik_autoscaling_min_capacity        = "1"
-    traefik_autoscaling_max_capacity        = "3"
-    traefik_autoscaling_scale_up_cooldown   = "60"
-    traefik_autoscaling_scale_down_cooldown = "60"
+    traefik_autoscaling_min_capacity        = 1
+    traefik_autoscaling_max_capacity        = 3
+    traefik_autoscaling_scale_up_cooldown   = 60
+    traefik_autoscaling_scale_down_cooldown = 60
 
-    traefik_ecs_alarms_enabled                        = "true"
-    traefik_ecs_alarms_cpu_utilization_high_threshold = "20"
-    traefik_ecs_alarms_cpu_utilization_low_threshold  = "10"
+    traefik_ecs_alarms_enabled                        = true
+    traefik_ecs_alarms_cpu_utilization_high_threshold = 20
+    traefik_ecs_alarms_cpu_utilization_low_threshold  = 10
   }
   ```
 

--- a/main.tf
+++ b/main.tf
@@ -26,7 +26,7 @@ data "aws_region" "current" {
 locals {
   enable_http_on_alb       = var.alb_http_enabled && var.alb_https_enabled && var.alb_http_to_https_redirect_enabled ? false : var.alb_http_enabled
   redirect_resources_count = local.enable_http_on_alb ? 1 : 0
-  redirect_code            = var.alb_http_to_https_redirect_permanent ? "302" : "301"
+  redirect_code            = var.alb_http_to_https_redirect_permanent ? 302 : 301
 
   ec2_asg_resources_count = var.ec2_asg_enabled ? 1 : 0
   ec2_nat_setup           = var.vpc_nat_gateway_enabled || var.vpc_nat_instance_enabled
@@ -126,7 +126,9 @@ module "ecs_instance_label" {
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage
-  tags       = merge({ "Cluster" = module.ecs.this_ecs_cluster_name }, var.tags)
+  tags       = merge({
+    "Cluster" = module.ecs.this_ecs_cluster_name
+  }, var.tags)
 }
 
 data "aws_iam_policy_document" "ecs_instance_assume_role_policy" {
@@ -199,7 +201,7 @@ module "autoscaling_group" {
   tags       = module.ecs_instance_label.tags
 
   security_group_ids = [var.ec2_asg_security_group_ids, aws_security_group.ecs_instance[0].id]
-  subnet_ids         = local.vpc_subnets_ids[local.ec2_nat_setup ? "private" : "public"]
+  subnet_ids         = local.ec2_nat_setup ? module.dynamic_subnets.private_subnet_ids : module.dynamic_subnets.public_subnet_ids
 
   image_id                             = data.aws_ami.amazon_linux_ecs[0].id
   instance_type                        = var.ec2_asg_instance_type

--- a/main.tf
+++ b/main.tf
@@ -372,7 +372,7 @@ resource "aws_sns_topic" "default" {
 #############################################################
 
 module "traefik" {
-  source     = "git::https://github.com/aleks-fofanov/terraform-aws-ecs-traefik-service.git?ref=terraform012_migration"
+  source     = "git::https://github.com/aleks-fofanov/terraform-aws-ecs-traefik-service.git?ref=tags/2.0.0"
   attributes = compact(concat(var.attributes, ["traefik"]))
   delimiter  = var.delimiter
   name       = var.name

--- a/main.tf
+++ b/main.tf
@@ -3,32 +3,33 @@
 #############################################################
 
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.11.1"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 }
 
 #############################################################
 # Common Datasources
 #############################################################
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 #############################################################
 # Locals
 #############################################################
 
 locals {
-  enable_http_on_alb       = "${var.alb_http_enabled == "true" && var.alb_https_enabled == "true" && var.alb_http_to_https_redirect_enabled == "true" ? "false" : var.alb_http_enabled}"
-  redirect_resources_count = "${local.enable_http_on_alb == "false" ? 1 : 0}"
-  redirect_code            = "${var.alb_http_to_https_redirect_permanent == "true" ? "302" : "301"}"
+  enable_http_on_alb       = var.alb_http_enabled && var.alb_https_enabled && var.alb_http_to_https_redirect_enabled ? false : var.alb_http_enabled
+  redirect_resources_count = local.enable_http_on_alb ? 1 : 0
+  redirect_code            = var.alb_http_to_https_redirect_permanent ? "302" : "301"
 
-  ec2_asg_resources_count = "${var.ec2_asg_enabled == "true" ? 1 : 0}"
-  ec2_nat_setup           = "${var.vpc_nat_gateway_enabled == "true" || var.vpc_nat_instance_enabled == "true"}"
+  ec2_asg_resources_count = var.ec2_asg_enabled ? 1 : 0
+  ec2_nat_setup           = var.vpc_nat_gateway_enabled || var.vpc_nat_instance_enabled
 }
 
 #############################################################
@@ -36,35 +37,35 @@ locals {
 #############################################################
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.4.1"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.8.1"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 
-  cidr_block = "${var.vpc_cidr_block}"
+  cidr_block = var.vpc_cidr_block
 }
 
 module "dynamic_subnets" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=0.12.0"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=0.18.1"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 
-  availability_zones      = ["${var.vpc_availability_zones}"]
-  vpc_id                  = "${module.vpc.vpc_id}"
-  igw_id                  = "${module.vpc.igw_id}"
-  cidr_block              = "${var.vpc_cidr_block}"
-  nat_gateway_enabled     = "${var.vpc_nat_gateway_enabled}"
-  nat_instance_enabled    = "${var.vpc_nat_instance_enabled}"
-  nat_instance_type       = "${var.vpc_nat_instance_type}"
-  map_public_ip_on_launch = "${var.vpc_map_public_ip_on_launch}"
-  max_subnet_count        = "${var.vpc_max_subnet_count}"
+  availability_zones      = var.vpc_availability_zones
+  vpc_id                  = module.vpc.vpc_id
+  igw_id                  = module.vpc.igw_id
+  cidr_block              = var.vpc_cidr_block
+  nat_gateway_enabled     = var.vpc_nat_gateway_enabled
+  nat_instance_enabled    = var.vpc_nat_instance_enabled
+  nat_instance_type       = var.vpc_nat_instance_type
+  map_public_ip_on_launch = var.vpc_map_public_ip_on_launch
+  max_subnet_count        = var.vpc_max_subnet_count
 }
 
 #############################################################
@@ -73,10 +74,10 @@ module "dynamic_subnets" {
 
 module "ecs" {
   source  = "terraform-aws-modules/ecs/aws"
-  version = "~> 1.4.0"
+  version = "~> 2.0.0"
 
-  name = "${module.default_label.id}"
-  tags = "${module.default_label.tags}"
+  name = module.default_label.id
+  tags = module.default_label.tags
 }
 
 #############################################################
@@ -84,7 +85,7 @@ module "ecs" {
 #############################################################
 
 data "aws_ami" "amazon_linux_ecs" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
   most_recent = true
 
@@ -113,23 +114,23 @@ USERDATA
 
   # https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-networking.html
   vpc_subnets_ids = {
-    private = "${module.dynamic_subnets.private_subnet_ids}"
-    public  = "${module.dynamic_subnets.public_subnet_ids}"
+    private = module.dynamic_subnets.private_subnet_ids
+    public  = module.dynamic_subnets.public_subnet_ids
   }
 }
 
 module "ecs_instance_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.11.1"
-  attributes = ["${compact(concat(var.attributes, list("ecs","instance")))}"]
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${merge(map("Cluster", "${module.ecs.this_ecs_cluster_name}"), var.tags)}"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.16.0"
+  attributes = [compact(concat(var.attributes, ["ecs", "instance"]))]
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = merge({ "Cluster" = module.ecs.this_ecs_cluster_name }, var.tags)
 }
 
 data "aws_iam_policy_document" "ecs_instance_assume_role_policy" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
   statement {
     actions = ["sts:AssumeRole"]
@@ -142,116 +143,116 @@ data "aws_iam_policy_document" "ecs_instance_assume_role_policy" {
 }
 
 resource "aws_iam_role" "ecs_instance" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
-  name               = "${module.ecs_instance_label.id}"
-  assume_role_policy = "${data.aws_iam_policy_document.ecs_instance_assume_role_policy.json}"
+  name               = module.ecs_instance_label.id
+  assume_role_policy = data.aws_iam_policy_document.ecs_instance_assume_role_policy[0].json
   path               = "/"
 
-  tags = "${module.ecs_instance_label.tags}"
+  tags = module.ecs_instance_label.tags
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_instance" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
-  role       = "${aws_iam_role.ecs_instance.name}"
+  role       = aws_iam_role.ecs_instance[0].name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
 }
 
 resource "aws_iam_instance_profile" "ecs_instance" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
-  name = "${module.ecs_instance_label.id}"
-  role = "${aws_iam_role.ecs_instance.name}"
+  name = module.ecs_instance_label.id
+  role = aws_iam_role.ecs_instance[0].name
 }
 
 resource "aws_security_group" "ecs_instance" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
-  name   = "${module.ecs_instance_label.id}"
-  vpc_id = "${module.vpc.vpc_id}"
+  name   = module.ecs_instance_label.id
+  vpc_id = module.vpc.vpc_id
 
-  tags = "${module.ecs_instance_label.tags}"
+  tags = module.ecs_instance_label.tags
 }
 
 resource "aws_security_group_rule" "ecs_instance_egress" {
-  count = "${local.ec2_asg_resources_count}"
+  count = local.ec2_asg_resources_count
 
   type              = "egress"
-  security_group_id = "${aws_security_group.ecs_instance.id}"
+  security_group_id = aws_security_group.ecs_instance[0].id
 
-  to_port     = "0"
-  from_port   = "0"
+  to_port     = 0
+  from_port   = 0
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 }
 
 module "autoscaling_group" {
-  enabled = "${var.ec2_asg_enabled == "true"}"
+  enabled = var.ec2_asg_enabled
 
-  source     = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.1.3"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${module.ecs_instance_label.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-ec2-autoscale-group.git?ref=tags/0.2.1"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = module.ecs_instance_label.tags
 
-  security_group_ids = ["${var.ec2_asg_security_group_ids}", "${aws_security_group.ecs_instance.id}"]
-  subnet_ids         = "${local.vpc_subnets_ids[local.ec2_nat_setup == "true" ? "private" : "public"]}"
+  security_group_ids = [var.ec2_asg_security_group_ids, aws_security_group.ecs_instance[0].id]
+  subnet_ids         = local.vpc_subnets_ids[local.ec2_nat_setup ? "private" : "public"]
 
-  image_id                             = "${data.aws_ami.amazon_linux_ecs.id}"
-  instance_type                        = "${var.ec2_asg_instance_type}"
-  instance_initiated_shutdown_behavior = "${var.ec2_asg_instance_initiated_shutdown_behavior}"
-  health_check_grace_period            = "${var.ec2_asg_health_check_grace_period}"
-  health_check_type                    = "${var.ec2_asg_health_check_type}"
-  key_name                             = "${var.ec2_asg_key_name}"
-  placement_group                      = "${var.ec2_asg_placement_group}"
-  iam_instance_profile_name            = "${aws_iam_instance_profile.ecs_instance.name}"
-  service_linked_role_arn              = "${var.ec2_asg_service_linked_role_arn}"
-  associate_public_ip_address          = "${local.ec2_nat_setup == "true" ? "false" : "true"}"
-  user_data_base64                     = "${base64encode(local.asg_ec2_userdata)}"
+  image_id                             = data.aws_ami.amazon_linux_ecs[0].id
+  instance_type                        = var.ec2_asg_instance_type
+  instance_initiated_shutdown_behavior = var.ec2_asg_instance_initiated_shutdown_behavior
+  health_check_grace_period            = var.ec2_asg_health_check_grace_period
+  health_check_type                    = var.ec2_asg_health_check_type
+  key_name                             = var.ec2_asg_key_name
+  placement_group                      = var.ec2_asg_placement_group
+  iam_instance_profile_name            = aws_iam_instance_profile.ecs_instance[0].name
+  service_linked_role_arn              = var.ec2_asg_service_linked_role_arn
+  associate_public_ip_address          = local.ec2_nat_setup ? false : true
+  user_data_base64                     = base64encode(local.asg_ec2_userdata)
 
-  ebs_optimized         = "${var.ec2_asg_ebs_optimized}"
-  block_device_mappings = "${var.ec2_asg_block_device_mappings}"
+  ebs_optimized         = var.ec2_asg_ebs_optimized
+  block_device_mappings = var.ec2_asg_block_device_mappings
 
-  instance_market_options    = "${var.ec2_asg_instance_market_options}"
-  placement                  = "${var.ec2_asg_placement}"
-  credit_specification       = "${var.ec2_asg_credit_specification}"
-  elastic_gpu_specifications = "${var.ec2_asg_elastic_gpu_specifications}"
+  instance_market_options    = var.ec2_asg_instance_market_options
+  placement                  = var.ec2_asg_placement
+  credit_specification       = var.ec2_asg_credit_specification
+  elastic_gpu_specifications = var.ec2_asg_elastic_gpu_specifications
 
-  disable_api_termination = "${var.ec2_asg_disable_api_termination}"
-  termination_policies    = "${var.ec2_asg_termination_policies}"
-  force_delete            = "${var.ec2_asg_force_delete}"
-  suspended_processes     = "${var.ec2_asg_suspended_processes}"
+  disable_api_termination = var.ec2_asg_disable_api_termination
+  termination_policies    = var.ec2_asg_termination_policies
+  force_delete            = var.ec2_asg_force_delete
+  suspended_processes     = var.ec2_asg_suspended_processes
 
-  min_size                  = "${var.ec2_asg_autoscaling_min_capacity}"
-  max_size                  = "${var.ec2_asg_autoscaling_max_capacity}"
-  wait_for_capacity_timeout = "${var.ec2_asg_wait_for_capacity_timeout}"
-  default_cooldown          = "${var.ec2_asg_default_cooldown}"
-  protect_from_scale_in     = "${var.ec2_asg_protect_from_scale_in}"
+  min_size                  = var.ec2_asg_autoscaling_min_capacity
+  max_size                  = var.ec2_asg_autoscaling_max_capacity
+  wait_for_capacity_timeout = var.ec2_asg_wait_for_capacity_timeout
+  default_cooldown          = var.ec2_asg_default_cooldown
+  protect_from_scale_in     = var.ec2_asg_protect_from_scale_in
 
-  enable_monitoring   = "${var.ec2_asg_enable_monitoring}"
-  enabled_metrics     = "${var.ec2_asg_enabled_metrics}"
-  metrics_granularity = "${var.ec2_asg_metrics_granularity}"
+  enable_monitoring   = var.ec2_asg_enable_monitoring
+  enabled_metrics     = var.ec2_asg_enabled_metrics
+  metrics_granularity = var.ec2_asg_metrics_granularity
 
-  autoscaling_policies_enabled            = "${var.ec2_asg_autoscaling_policies_enabled}"
-  scale_up_cooldown_seconds               = "${var.ec2_asg_autoscaling_scale_up_cooldown_seconds}"
-  scale_up_scaling_adjustment             = "${var.ec2_asg_autoscaling_scale_up_scaling_adjustment}"
-  scale_up_adjustment_type                = "${var.ec2_asg_autoscaling_scale_up_adjustment_type}"
-  scale_up_policy_type                    = "${var.ec2_asg_autoscaling_scale_up_policy_type}"
-  scale_down_cooldown_seconds             = "${var.ec2_asg_autoscaling_scale_down_cooldown_seconds}"
-  scale_down_scaling_adjustment           = "${var.ec2_asg_autoscaling_scale_down_scaling_adjustment}"
-  scale_down_adjustment_type              = "${var.ec2_asg_autoscaling_scale_down_adjustment_type}"
-  scale_down_policy_type                  = "${var.ec2_asg_autoscaling_scale_down_policy_type}"
-  cpu_utilization_high_evaluation_periods = "${var.ec2_asg_autoscaling_cpu_utilization_high_evaluation_periods}"
-  cpu_utilization_high_period_seconds     = "${var.ec2_asg_autoscaling_cpu_utilization_high_period_seconds}"
-  cpu_utilization_high_threshold_percent  = "${var.ec2_asg_autoscaling_cpu_utilization_high_threshold_percent}"
-  cpu_utilization_high_statistic          = "${var.ec2_asg_autoscaling_cpu_utilization_high_statistic}"
-  cpu_utilization_low_evaluation_periods  = "${var.ec2_asg_autoscaling_cpu_utilization_low_evaluation_periods}"
-  cpu_utilization_low_period_seconds      = "${var.ec2_asg_autoscaling_cpu_utilization_low_period_seconds}"
-  cpu_utilization_low_threshold_percent   = "${var.ec2_asg_autoscaling_cpu_utilization_low_threshold_percent}"
-  cpu_utilization_low_statistic           = "${var.ec2_asg_autoscaling_cpu_utilization_low_statistic}"
+  autoscaling_policies_enabled            = var.ec2_asg_autoscaling_policies_enabled
+  scale_up_cooldown_seconds               = var.ec2_asg_autoscaling_scale_up_cooldown_seconds
+  scale_up_scaling_adjustment             = var.ec2_asg_autoscaling_scale_up_scaling_adjustment
+  scale_up_adjustment_type                = var.ec2_asg_autoscaling_scale_up_adjustment_type
+  scale_up_policy_type                    = var.ec2_asg_autoscaling_scale_up_policy_type
+  scale_down_cooldown_seconds             = var.ec2_asg_autoscaling_scale_down_cooldown_seconds
+  scale_down_scaling_adjustment           = var.ec2_asg_autoscaling_scale_down_scaling_adjustment
+  scale_down_adjustment_type              = var.ec2_asg_autoscaling_scale_down_adjustment_type
+  scale_down_policy_type                  = var.ec2_asg_autoscaling_scale_down_policy_type
+  cpu_utilization_high_evaluation_periods = var.ec2_asg_autoscaling_cpu_utilization_high_evaluation_periods
+  cpu_utilization_high_period_seconds     = var.ec2_asg_autoscaling_cpu_utilization_high_period_seconds
+  cpu_utilization_high_threshold_percent  = var.ec2_asg_autoscaling_cpu_utilization_high_threshold_percent
+  cpu_utilization_high_statistic          = var.ec2_asg_autoscaling_cpu_utilization_high_statistic
+  cpu_utilization_low_evaluation_periods  = var.ec2_asg_autoscaling_cpu_utilization_low_evaluation_periods
+  cpu_utilization_low_period_seconds      = var.ec2_asg_autoscaling_cpu_utilization_low_period_seconds
+  cpu_utilization_low_threshold_percent   = var.ec2_asg_autoscaling_cpu_utilization_low_threshold_percent
+  cpu_utilization_low_statistic           = var.ec2_asg_autoscaling_cpu_utilization_low_statistic
 }
 
 #############################################################
@@ -259,64 +260,64 @@ module "autoscaling_group" {
 #############################################################
 
 module "alb" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.5.0"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.8.0"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 
-  vpc_id             = "${module.vpc.vpc_id}"
-  subnet_ids         = "${module.dynamic_subnets.public_subnet_ids}"
-  security_group_ids = "${var.alb_security_group_ids}"
-  certificate_arn    = "${var.alb_certificate_arn}"
+  vpc_id             = module.vpc.vpc_id
+  subnet_ids         = module.dynamic_subnets.public_subnet_ids
+  security_group_ids = var.alb_security_group_ids
+  certificate_arn    = var.alb_certificate_arn
 
-  internal                          = "false"
+  internal                          = false
   ip_address_type                   = "ipv4"
-  cross_zone_load_balancing_enabled = "true"
-  target_group_port                 = "${var.traefik_container_http_port}"
-  idle_timeout                      = "${var.alb_idle_timeout}"
-  deletion_protection_enabled       = "${var.alb_deletion_protection_enabled}"
+  cross_zone_load_balancing_enabled = true
+  target_group_port                 = var.traefik_container_http_port
+  idle_timeout                      = var.alb_idle_timeout
+  deletion_protection_enabled       = var.alb_deletion_protection_enabled
 
-  http_enabled                 = "${local.enable_http_on_alb}"
-  http_port                    = "${var.alb_http_port}"
-  http_ingress_cidr_blocks     = "${var.alb_http_ingress_cidr_blocks}"
-  http_ingress_prefix_list_ids = "${var.alb_http_ingress_prefix_list_ids}"
+  http_enabled                 = local.enable_http_on_alb
+  http_port                    = var.alb_http_port
+  http_ingress_cidr_blocks     = var.alb_http_ingress_cidr_blocks
+  http_ingress_prefix_list_ids = var.alb_http_ingress_prefix_list_ids
 
-  https_enabled                 = "${var.alb_https_enabled}"
-  https_port                    = "${var.alb_https_port}"
-  https_ingress_cidr_blocks     = "${var.alb_https_ingress_cidr_blocks}"
-  https_ingress_prefix_list_ids = "${var.alb_https_ingress_prefix_list_ids}"
-  https_ssl_policy              = "${var.alb_https_ssl_policy}"
+  https_enabled                 = var.alb_https_enabled
+  https_port                    = var.alb_https_port
+  https_ingress_cidr_blocks     = var.alb_https_ingress_cidr_blocks
+  https_ingress_prefix_list_ids = var.alb_https_ingress_prefix_list_ids
+  https_ssl_policy              = var.alb_https_ssl_policy
 
-  http2_enabled = "${var.alb_http2_enabled}"
+  http2_enabled = var.alb_http2_enabled
 
   # Traefik ping endpoint
   health_check_path                = "/ping"
-  health_check_timeout             = "10"
-  health_check_healthy_threshold   = "2"
-  health_check_unhealthy_threshold = "2"
-  health_check_interval            = "15"
+  health_check_timeout             = 10
+  health_check_healthy_threshold   = 2
+  health_check_unhealthy_threshold = 2
+  health_check_interval            = 15
 
-  access_logs_enabled                     = "${var.alb_access_logs_enabled}"
-  access_logs_region                      = "${var.alb_access_logs_region}"
-  access_logs_prefix                      = "${var.alb_access_logs_prefix}"
-  alb_access_logs_s3_bucket_force_destroy = "${var.alb_access_logs_s3_bucket_force_destroy}"
+  access_logs_enabled                     = var.alb_access_logs_enabled
+  access_logs_region                      = var.alb_access_logs_region
+  access_logs_prefix                      = var.alb_access_logs_prefix
+  alb_access_logs_s3_bucket_force_destroy = var.alb_access_logs_s3_bucket_force_destroy
 }
 
 resource "aws_lb_listener" "http_to_https_redirect" {
-  count = "${local.redirect_resources_count}"
+  count = local.redirect_resources_count
 
-  load_balancer_arn = "${module.alb.alb_arn}"
-  port              = "${var.alb_http_port}"
+  load_balancer_arn = module.alb.alb_arn
+  port              = var.alb_http_port
   protocol          = "HTTP"
 
   default_action {
     type = "redirect"
 
     redirect {
-      port        = "${var.alb_https_port}"
+      port        = var.alb_https_port
       protocol    = "HTTPS"
       status_code = "HTTP_${local.redirect_code}"
     }
@@ -324,139 +325,130 @@ resource "aws_lb_listener" "http_to_https_redirect" {
 }
 
 resource "aws_security_group_rule" "http_ingress" {
-  count = "${local.redirect_resources_count}"
+  count = local.redirect_resources_count
 
   type              = "ingress"
-  from_port         = "${var.alb_http_port}"
-  to_port           = "${var.alb_http_port}"
+  from_port         = var.alb_http_port
+  to_port           = var.alb_http_port
   protocol          = "tcp"
-  cidr_blocks       = ["${var.alb_http_ingress_cidr_blocks}"]
-  prefix_list_ids   = ["${var.alb_http_ingress_prefix_list_ids}"]
-  security_group_id = "${module.alb.security_group_id}"
+  cidr_blocks       = var.alb_http_ingress_cidr_blocks
+  prefix_list_ids   = var.alb_http_ingress_prefix_list_ids
+  security_group_id = module.alb.security_group_id
 }
 
-# The following data source is required to wait for ALB will to be
-# fully provisioned before creating ECS Service for ABL Target Group
-
 data "aws_alb_target_group" "default" {
-  arn = "${module.alb.default_target_group_arn}"
+  arn = module.alb.default_target_group_arn
 }
 
 module "alb_target_group_alarms" {
-  enabled = "${var.alb_target_group_alarms_enabled}"
+  enabled = var.alb_target_group_alarms_enabled
 
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.5.0"
-  attributes = "${var.attributes}"
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.7.0"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 
-  alb_name                       = "${module.alb.alb_name}"
-  alb_arn_suffix                 = "${module.alb.alb_arn_suffix}"
-  target_group_name              = "${data.aws_alb_target_group.default.name}"
-  target_group_arn_suffix        = "${data.aws_alb_target_group.default.arn_suffix}"
-  target_3xx_count_threshold     = "${var.alb_target_group_alarms_3xx_threshold}"
-  target_4xx_count_threshold     = "${var.alb_target_group_alarms_4xx_threshold}"
-  target_5xx_count_threshold     = "${var.alb_target_group_alarms_5xx_threshold}"
-  target_response_time_threshold = "${var.alb_target_group_alarms_response_time_threshold}"
-  period                         = "${var.alb_target_group_alarms_period}"
-  evaluation_periods             = "${var.alb_target_group_alarms_evaluation_periods}"
+  alb_name                       = module.alb.alb_name
+  alb_arn_suffix                 = module.alb.alb_arn_suffix
+  target_group_name              = data.aws_alb_target_group.default.name
+  target_group_arn_suffix        = data.aws_alb_target_group.default.arn_suffix
+  target_3xx_count_threshold     = var.alb_target_group_alarms_3xx_threshold
+  target_4xx_count_threshold     = var.alb_target_group_alarms_4xx_threshold
+  target_5xx_count_threshold     = var.alb_target_group_alarms_5xx_threshold
+  target_response_time_threshold = var.alb_target_group_alarms_response_time_threshold
+  period                         = var.alb_target_group_alarms_period
+  evaluation_periods             = var.alb_target_group_alarms_evaluation_periods
 
-  ok_actions                = "${var.alb_target_group_alarms_ok_actions}"
-  alarm_actions             = "${var.alb_target_group_alarms_alarm_actions}"
-  insufficient_data_actions = "${var.alb_target_group_alarms_insufficient_data_actions}"
+  ok_actions                = var.alb_target_group_alarms_ok_actions
+  alarm_actions             = var.alb_target_group_alarms_alarm_actions
+  insufficient_data_actions = var.alb_target_group_alarms_insufficient_data_actions
 }
 
 #############################################################
 # Traefik
 #############################################################
 
-data "aws_alb_target_group" "traefik" {
-  depends_on = ["module.alb"]
-
-  arn = "${module.alb.default_target_group_arn}"
-}
-
 module "traefik" {
-  source     = "git::https://github.com/aleks-fofanov/terraform-aws-ecs-traefik-service.git?ref=tags/0.1.1"
-  attributes = ["${compact(concat(var.attributes, list("traefik")))}"]
-  delimiter  = "${var.delimiter}"
-  name       = "${var.name}"
-  namespace  = "${var.namespace}"
-  stage      = "${var.stage}"
-  tags       = "${var.tags}"
+  source     = "git::https://github.com/aleks-fofanov/terraform-aws-ecs-traefik-service.git?ref=terraform012_migration"
+  attributes = [compact(concat(var.attributes, ["traefik"]))]
+  delimiter  = var.delimiter
+  name       = var.name
+  namespace  = var.namespace
+  stage      = var.stage
+  tags       = var.tags
 
-  ecs_cluster_name      = "${module.ecs.this_ecs_cluster_name}"
-  ecs_cluster_arn       = "${module.ecs.this_ecs_cluster_arn}"
-  ecs_cluster_region    = "${data.aws_region.current.name}"
-  alb_security_group_id = "${module.alb.security_group_id}"
-  alb_target_group_arn  = "${data.aws_alb_target_group.traefik.arn}"
-  vpc_id                = "${module.vpc.vpc_id}"
-  subnet_ids            = "${module.dynamic_subnets.public_subnet_ids}"
+  ecs_cluster_name      = module.ecs.this_ecs_cluster_name
+  ecs_cluster_arn       = module.ecs.this_ecs_cluster_arn
+  ecs_cluster_region    = data.aws_region.current.name
+  alb_security_group_id = module.alb.security_group_id
+  alb_target_group_arn  = module.alb.default_target_group_arn
+  vpc_id                = module.vpc.vpc_id
+  subnet_ids            = module.dynamic_subnets.public_subnet_ids
 
-  launch_type      = "${var.traefik_launch_type}"
-  assign_public_ip = "${var.traefik_assign_public_ip}"
+  launch_type      = var.traefik_launch_type
+  assign_public_ip = var.traefik_assign_public_ip
 
-  container_name          = "${var.traefik_container_name}"
-  task_image              = "${var.traefik_task_image}"
-  task_cpu                = "${var.traefik_task_cpu}"
-  task_memory             = "${var.traefik_task_memory}"
-  task_memory_reservation = "${var.traefik_task_memory_reservation}"
-  log_level               = "${var.traefik_log_level}"
-  log_format              = "${var.traefik_log_format}"
-  logs_retention          = "${var.traefik_logs_retention}"
-  logs_region             = "${var.traefik_logs_region}"
+  container_name          = var.traefik_container_name
+  task_image              = var.traefik_task_image
+  task_cpu                = var.traefik_task_cpu
+  task_memory             = var.traefik_task_memory
+  task_memory_reservation = var.traefik_task_memory_reservation
+  log_level               = var.traefik_log_level
+  log_format              = var.traefik_log_format
+  logs_retention          = var.traefik_logs_retention
+  logs_region             = var.traefik_logs_region
 
-  http_port = "${var.traefik_container_http_port}"
+  http_port = var.traefik_container_http_port
 
-  dashboard_enabled             = "${var.traefik_dashboard_enabled}"
-  dashboard_host                = "${var.traefik_dashboard_host}"
-  dashboard_basic_auth_user     = "${var.traefik_dashboard_basic_auth_user}"
-  dashboard_basic_auth_password = "${var.traefik_dashboard_basic_auth_password}"
+  dashboard_enabled             = var.traefik_dashboard_enabled
+  dashboard_host                = var.traefik_dashboard_host
+  dashboard_basic_auth_user     = var.traefik_dashboard_basic_auth_user
+  dashboard_basic_auth_password = var.traefik_dashboard_basic_auth_password
 
-  desired_count                      = "${var.traefik_desired_count}"
-  deployment_controller_type         = "${var.traefik_deployment_controller_type}"
-  deployment_maximum_percent         = "${var.traefik_deployment_maximum_percent}"
-  deployment_minimum_healthy_percent = "${var.traefik_deployment_minimum_healthy_percent}"
+  desired_count                      = var.traefik_desired_count
+  deployment_controller_type         = var.traefik_deployment_controller_type
+  deployment_maximum_percent         = var.traefik_deployment_maximum_percent
+  deployment_minimum_healthy_percent = var.traefik_deployment_minimum_healthy_percent
 
-  mount_points = "${var.traefik_mount_points}"
-  volumes      = "${var.traefik_volumes}"
+  mount_points = var.traefik_mount_points
+  volumes      = var.traefik_volumes
 
-  ignore_changes_task_definition = "${var.traefik_ignore_changes_task_definition}"
+  ignore_changes_task_definition = var.traefik_ignore_changes_task_definition
 
-  autoscaling_enabled = "${var.traefik_autoscaling_enabled}"
+  autoscaling_enabled = var.traefik_autoscaling_enabled
 
-  autoscaling_dimension             = "${var.traefik_autoscaling_dimension}"
-  autoscaling_min_capacity          = "${var.traefik_autoscaling_min_capacity}"
-  autoscaling_max_capacity          = "${var.traefik_autoscaling_max_capacity}"
-  autoscaling_scale_up_adjustment   = "${var.traefik_autoscaling_scale_up_adjustment}"
-  autoscaling_scale_up_cooldown     = "${var.traefik_autoscaling_scale_up_cooldown}"
-  autoscaling_scale_down_adjustment = "${var.traefik_autoscaling_scale_down_adjustment}"
-  autoscaling_scale_down_cooldown   = "${var.traefik_autoscaling_scale_down_cooldown}"
+  autoscaling_dimension             = var.traefik_autoscaling_dimension
+  autoscaling_min_capacity          = var.traefik_autoscaling_min_capacity
+  autoscaling_max_capacity          = var.traefik_autoscaling_max_capacity
+  autoscaling_scale_up_adjustment   = var.traefik_autoscaling_scale_up_adjustment
+  autoscaling_scale_up_cooldown     = var.traefik_autoscaling_scale_up_cooldown
+  autoscaling_scale_down_adjustment = var.traefik_autoscaling_scale_down_adjustment
+  autoscaling_scale_down_cooldown   = var.traefik_autoscaling_scale_down_cooldown
 
-  ecs_alarms_enabled = "${var.traefik_ecs_alarms_enabled}"
+  ecs_alarms_enabled = var.traefik_ecs_alarms_enabled
 
-  ecs_alarms_cpu_utilization_high_threshold          = "${var.traefik_ecs_alarms_cpu_utilization_high_threshold}"
-  ecs_alarms_cpu_utilization_high_evaluation_periods = "${var.traefik_ecs_alarms_cpu_utilization_high_evaluation_periods}"
-  ecs_alarms_cpu_utilization_high_period             = "${var.traefik_ecs_alarms_cpu_utilization_high_period}"
-  ecs_alarms_cpu_utilization_high_alarm_actions      = "${var.traefik_ecs_alarms_cpu_utilization_high_alarm_actions}"
-  ecs_alarms_cpu_utilization_high_ok_actions         = "${var.traefik_ecs_alarms_cpu_utilization_high_ok_actions}"
-  ecs_alarms_cpu_utilization_low_threshold           = "${var.traefik_ecs_alarms_cpu_utilization_low_threshold}"
-  ecs_alarms_cpu_utilization_low_evaluation_periods  = "${var.traefik_ecs_alarms_cpu_utilization_low_evaluation_periods}"
-  ecs_alarms_cpu_utilization_low_period              = "${var.traefik_ecs_alarms_cpu_utilization_low_period}"
-  ecs_alarms_cpu_utilization_low_alarm_actions       = "${var.traefik_ecs_alarms_cpu_utilization_low_alarm_actions}"
-  ecs_alarms_cpu_utilization_low_ok_actions          = "${var.traefik_ecs_alarms_cpu_utilization_low_ok_actions}"
+  ecs_alarms_cpu_utilization_high_threshold          = var.traefik_ecs_alarms_cpu_utilization_high_threshold
+  ecs_alarms_cpu_utilization_high_evaluation_periods = var.traefik_ecs_alarms_cpu_utilization_high_evaluation_periods
+  ecs_alarms_cpu_utilization_high_period             = var.traefik_ecs_alarms_cpu_utilization_high_period
+  ecs_alarms_cpu_utilization_high_alarm_actions      = var.traefik_ecs_alarms_cpu_utilization_high_alarm_actions
+  ecs_alarms_cpu_utilization_high_ok_actions         = var.traefik_ecs_alarms_cpu_utilization_high_ok_actions
+  ecs_alarms_cpu_utilization_low_threshold           = var.traefik_ecs_alarms_cpu_utilization_low_threshold
+  ecs_alarms_cpu_utilization_low_evaluation_periods  = var.traefik_ecs_alarms_cpu_utilization_low_evaluation_periods
+  ecs_alarms_cpu_utilization_low_period              = var.traefik_ecs_alarms_cpu_utilization_low_period
+  ecs_alarms_cpu_utilization_low_alarm_actions       = var.traefik_ecs_alarms_cpu_utilization_low_alarm_actions
+  ecs_alarms_cpu_utilization_low_ok_actions          = var.traefik_ecs_alarms_cpu_utilization_low_ok_actions
 
-  ecs_alarms_memory_utilization_high_threshold          = "${var.traefik_ecs_alarms_memory_utilization_high_threshold}"
-  ecs_alarms_memory_utilization_high_evaluation_periods = "${var.traefik_ecs_alarms_memory_utilization_high_evaluation_periods}"
-  ecs_alarms_memory_utilization_high_period             = "${var.traefik_ecs_alarms_memory_utilization_high_period}"
-  ecs_alarms_memory_utilization_high_alarm_actions      = "${var.traefik_ecs_alarms_memory_utilization_high_alarm_actions}"
-  ecs_alarms_memory_utilization_high_ok_actions         = "${var.traefik_ecs_alarms_memory_utilization_high_ok_actions}"
-  ecs_alarms_memory_utilization_low_threshold           = "${var.traefik_ecs_alarms_memory_utilization_low_threshold}"
-  ecs_alarms_memory_utilization_low_evaluation_periods  = "${var.traefik_ecs_alarms_memory_utilization_low_evaluation_periods}"
-  ecs_alarms_memory_utilization_low_period              = "${var.traefik_ecs_alarms_memory_utilization_low_period}"
-  ecs_alarms_memory_utilization_low_alarm_actions       = "${var.traefik_ecs_alarms_memory_utilization_low_alarm_actions}"
-  ecs_alarms_memory_utilization_low_ok_actions          = "${var.traefik_ecs_alarms_memory_utilization_low_ok_actions}"
+  ecs_alarms_memory_utilization_high_threshold          = var.traefik_ecs_alarms_memory_utilization_high_threshold
+  ecs_alarms_memory_utilization_high_evaluation_periods = var.traefik_ecs_alarms_memory_utilization_high_evaluation_periods
+  ecs_alarms_memory_utilization_high_period             = var.traefik_ecs_alarms_memory_utilization_high_period
+  ecs_alarms_memory_utilization_high_alarm_actions      = var.traefik_ecs_alarms_memory_utilization_high_alarm_actions
+  ecs_alarms_memory_utilization_high_ok_actions         = var.traefik_ecs_alarms_memory_utilization_high_ok_actions
+  ecs_alarms_memory_utilization_low_threshold           = var.traefik_ecs_alarms_memory_utilization_low_threshold
+  ecs_alarms_memory_utilization_low_evaluation_periods  = var.traefik_ecs_alarms_memory_utilization_low_evaluation_periods
+  ecs_alarms_memory_utilization_low_period              = var.traefik_ecs_alarms_memory_utilization_low_period
+  ecs_alarms_memory_utilization_low_alarm_actions       = var.traefik_ecs_alarms_memory_utilization_low_alarm_actions
+  ecs_alarms_memory_utilization_low_ok_actions          = var.traefik_ecs_alarms_memory_utilization_low_ok_actions
 }

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ module "ecs_instance_label" {
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage
-  tags = merge({
+  tags       = merge({
     "Cluster" = module.ecs.this_ecs_cluster_name
   }, var.tags)
 }
@@ -339,7 +339,7 @@ data "aws_alb_target_group" "default" {
 module "alb_target_group_alarms" {
   enabled = var.alb_target_group_alarms_enabled
 
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.7.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.8.0"
   attributes = var.attributes
   delimiter  = var.delimiter
   name       = var.name
@@ -356,15 +356,9 @@ module "alb_target_group_alarms" {
   period                         = var.alb_target_group_alarms_period
   evaluation_periods             = var.alb_target_group_alarms_evaluation_periods
 
-  # https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms/pull/18
-  ok_actions                = [aws_sns_topic.default.arn]
-  alarm_actions             = [aws_sns_topic.default.arn]
-  insufficient_data_actions = [aws_sns_topic.default.arn]
-  notify_arns               = [aws_sns_topic.default.arn]
-}
-
-resource "aws_sns_topic" "default" {
-  name = "test"
+  ok_actions                = var.alb_target_group_alarms_ok_actions
+  alarm_actions             = var.alb_target_group_alarms_alarm_actions
+  insufficient_data_actions = var.alb_target_group_alarms_insufficient_data_actions
 }
 
 #############################################################

--- a/main.tf
+++ b/main.tf
@@ -120,7 +120,7 @@ module "ecs_instance_label" {
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage
-  tags       = merge({
+  tags = merge({
     "Cluster" = module.ecs.this_ecs_cluster_name
   }, var.tags)
 }
@@ -256,7 +256,7 @@ module "autoscaling_group" {
 #############################################################
 
 module "alb" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.8.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.9.0"
   attributes = var.attributes
   delimiter  = var.delimiter
   name       = var.name
@@ -333,6 +333,8 @@ resource "aws_security_group_rule" "http_ingress" {
 }
 
 data "aws_alb_target_group" "default" {
+  depends_on = [module.alb]
+
   arn = module.alb.default_target_group_arn
 }
 
@@ -378,7 +380,7 @@ module "traefik" {
   ecs_cluster_arn       = module.ecs.this_ecs_cluster_arn
   ecs_cluster_region    = data.aws_region.current.name
   alb_security_group_id = module.alb.security_group_id
-  alb_target_group_arn  = module.alb.default_target_group_arn
+  alb_target_group_arn  = data.aws_alb_target_group.default.arn
   vpc_id                = module.vpc.vpc_id
   subnet_ids            = module.dynamic_subnets.public_subnet_ids
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,269 +1,269 @@
 output "vpc_igw_id" {
-  value       = "${module.vpc.igw_id}"
+  value       = module.vpc.igw_id
   description = "The ID of the Internet Gateway"
 }
 
 output "vpc_id" {
-  value       = "${module.vpc.vpc_id}"
+  value       = module.vpc.vpc_id
   description = "The ID of the VPC"
 }
 
 output "vpc_cidr_block" {
-  value       = "${module.vpc.vpc_cidr_block}"
+  value       = module.vpc.vpc_cidr_block
   description = "The CIDR block of the VPC"
 }
 
 output "vpc_main_route_table_id" {
-  value       = "${module.vpc.vpc_main_route_table_id}"
+  value       = module.vpc.vpc_main_route_table_id
   description = "The ID of the main route table associated with this VPC."
 }
 
 output "vpc_default_network_acl_id" {
-  value       = "${module.vpc.vpc_default_network_acl_id}"
+  value       = module.vpc.vpc_default_network_acl_id
   description = "The ID of the network ACL created by default on VPC creation"
 }
 
 output "vpc_default_security_group_id" {
-  value       = "${module.vpc.vpc_default_security_group_id}"
+  value       = module.vpc.vpc_default_security_group_id
   description = "The ID of the security group created by default on VPC creation"
 }
 
 output "vpc_default_route_table_id" {
-  value       = "${module.vpc.vpc_default_route_table_id}"
+  value       = module.vpc.vpc_default_route_table_id
   description = "The ID of the route table created by default on VPC creation"
 }
 
 output "vpc_public_subnet_ids" {
   description = "IDs of the created public subnets"
-  value       = "${module.dynamic_subnets.public_subnet_ids}"
+  value       = module.dynamic_subnets.public_subnet_ids
 }
 
 output "vpc_private_subnet_ids" {
   description = "IDs of the created private subnets"
-  value       = "${module.dynamic_subnets.private_subnet_ids}"
+  value       = module.dynamic_subnets.private_subnet_ids
 }
 
 output "vpc_public_subnet_cidrs" {
   description = "CIDR blocks of the created public subnets"
-  value       = "${module.dynamic_subnets.public_subnet_cidrs}"
+  value       = module.dynamic_subnets.public_subnet_cidrs
 }
 
 output "vpc_private_subnet_cidrs" {
   description = "CIDR blocks of the created private subnets"
-  value       = "${module.dynamic_subnets.private_subnet_cidrs}"
+  value       = module.dynamic_subnets.private_subnet_cidrs
 }
 
 output "vpc_public_route_table_ids" {
   description = "IDs of the created public route tables"
-  value       = "${module.dynamic_subnets.public_route_table_ids}"
+  value       = module.dynamic_subnets.public_route_table_ids
 }
 
 output "vpc_private_route_table_ids" {
   description = "IDs of the created private route tables"
-  value       = "${module.dynamic_subnets.private_route_table_ids}"
+  value       = module.dynamic_subnets.private_route_table_ids
 }
 
 output "vpc_nat_gateway_ids" {
   description = "IDs of the NAT Gateways created"
-  value       = "${module.dynamic_subnets.nat_gateway_ids}"
+  value       = module.dynamic_subnets.nat_gateway_ids
 }
 
 output "vpc_nat_instance_ids" {
   description = "IDs of the NAT Instances created"
-  value       = "${module.dynamic_subnets.nat_instance_ids}"
+  value       = module.dynamic_subnets.nat_instance_ids
 }
 
 output "vpc_availability_zones" {
   description = "List of Availability Zones where subnets were created"
-  value       = "${module.dynamic_subnets.availability_zones}"
+  value       = module.dynamic_subnets.availability_zones
 }
 
 output "ecs_cluster_id" {
-  value       = "${module.ecs.this_ecs_cluster_id}"
+  value       = module.ecs.this_ecs_cluster_id
   description = "Id of ECS cluster"
 }
 
 output "ecs_cluster_name" {
-  value       = "${module.ecs.this_ecs_cluster_name}"
+  value       = module.ecs.this_ecs_cluster_name
   description = "Name of ECS cluster"
 }
 
 output "ecs_cluster_arn" {
-  value       = "${module.ecs.this_ecs_cluster_arn}"
+  value       = module.ecs.this_ecs_cluster_arn
   description = "ARN of ECS cluster"
 }
 
 output "ec2_instance_role_arn" {
-  value       = "${join("", aws_iam_role.ecs_instance.*.arn)}"
+  value       = join("", aws_iam_role.ecs_instance.*.arn)
   description = "ARN of IAM role assumed by ECS cluster instances launched in EC2 ASG"
 }
 
 output "ec2_instance_role_name" {
-  value       = "${join("", aws_iam_role.ecs_instance.*.name)}"
+  value       = join("", aws_iam_role.ecs_instance.*.name)
   description = "Name of IAM role assumed by ECS cluster instances launched in EC2 ASG"
 }
 
 output "ec2_instance_profile_name" {
-  value       = "${join("", aws_iam_instance_profile.ecs_instance.*.name)}"
+  value       = join("", aws_iam_instance_profile.ecs_instance.*.name)
   description = "Name of instance profile used with ECS cluster instances launched in EC2 ASG"
 }
 
 output "ec2_instance_profile_arn" {
-  value       = "${join("", aws_iam_instance_profile.ecs_instance.*.arn)}"
+  value       = join("", aws_iam_instance_profile.ecs_instance.*.arn)
   description = "ARN of instance profile used with ECS cluster instances launched in EC2 ASG"
 }
 
 output "ec2_instance_security_group_id" {
-  value       = "${join("", aws_security_group.ecs_instance.*.id)}"
+  value       = join("", aws_security_group.ecs_instance.*.id)
   description = "Id of secufity group associated with ECS cluster instances launched in EC2 ASG"
 }
 
 output "ec2_launch_template_id" {
   description = "The ID of the launch template"
-  value       = "${module.autoscaling_group.launch_template_id}"
+  value       = module.autoscaling_group.launch_template_id
 }
 
 output "ec2_launch_template_arn" {
   description = "The ARN of the launch template"
-  value       = "${module.autoscaling_group.launch_template_arn}"
+  value       = module.autoscaling_group.launch_template_arn
 }
 
 output "ec2_autoscaling_group_id" {
   description = "The autoscaling group id"
-  value       = "${module.autoscaling_group.autoscaling_group_id}"
+  value       = module.autoscaling_group.autoscaling_group_id
 }
 
 output "ec2_autoscaling_group_name" {
   description = "The autoscaling group name"
-  value       = "${module.autoscaling_group.autoscaling_group_name}"
+  value       = module.autoscaling_group.autoscaling_group_name
 }
 
 output "ec2_autoscaling_group_arn" {
   description = "The ARN for this AutoScaling Group"
-  value       = "${module.autoscaling_group.autoscaling_group_arn}"
+  value       = module.autoscaling_group.autoscaling_group_arn
 }
 
 output "alb_name" {
   description = "The name of the ALB"
-  value       = "${module.alb.alb_name}"
+  value       = module.alb.alb_name
 }
 
 output "alb_arn" {
   description = "The ARN of the ALB"
-  value       = "${module.alb.alb_arn}"
+  value       = module.alb.alb_arn
 }
 
 output "alb_arn_suffix" {
   description = "The ARN suffix of the ALB"
-  value       = "${module.alb.alb_arn_suffix}"
+  value       = module.alb.alb_arn_suffix
 }
 
 output "alb_dns_name" {
   description = "DNS name of ALB"
-  value       = "${module.alb.alb_dns_name}"
+  value       = module.alb.alb_dns_name
 }
 
 output "alb_zone_id" {
   description = "The ID of the zone which ALB is provisioned"
-  value       = "${module.alb.alb_zone_id}"
+  value       = module.alb.alb_zone_id
 }
 
 output "alb_security_group_id" {
   description = "The security group ID of the ALB"
-  value       = "${module.alb.security_group_id}"
+  value       = module.alb.security_group_id
 }
 
 output "alb_default_target_group_arn" {
   description = "The default target group ARN"
-  value       = "${module.alb.default_target_group_arn}"
+  value       = module.alb.default_target_group_arn
 }
 
 output "alb_http_listener_arn" {
   description = "The ARN of the HTTP listener"
-  value       = "${module.alb.http_listener_arn}"
+  value       = module.alb.http_listener_arn
 }
 
 output "alb_https_listener_arn" {
   description = "The ARN of the HTTPS listener"
-  value       = "${module.alb.https_listener_arn}"
+  value       = module.alb.https_listener_arn
 }
 
 output "alb_listener_arns" {
   description = "A list of all the listener ARNs"
-  value       = "${module.alb.listener_arns}"
+  value       = module.alb.listener_arns
 }
 
 output "alb_access_logs_bucket_id" {
   description = "The S3 bucket ID for access logs"
-  value       = "${module.alb.access_logs_bucket_id}"
+  value       = module.alb.access_logs_bucket_id
 }
 
 output "traefik_ecs_exec_role_policy_id" {
   description = "The ECS service role policy ID, in the form of role_name:role_policy_name"
-  value       = "${module.traefik.ecs_exec_role_policy_id}"
+  value       = module.traefik.ecs_exec_role_policy_id
 }
 
 output "traefik_ecs_exec_role_policy_name" {
   description = "ECS service role name"
-  value       = "${module.traefik.ecs_exec_role_policy_name}"
+  value       = module.traefik.ecs_exec_role_policy_name
 }
 
 output "traefik_service_name" {
   description = "ECS Service name"
-  value       = "${module.traefik.service_name}"
+  value       = module.traefik.service_name
 }
 
 output "traefik_service_role_arn" {
   description = "ECS Service role ARN"
-  value       = "${module.traefik.service_role_arn}"
+  value       = module.traefik.service_role_arn
 }
 
 output "traefik_task_exec_role_name" {
   description = "ECS Task role name"
-  value       = "${module.traefik.task_exec_role_name}"
+  value       = module.traefik.task_exec_role_name
 }
 
 output "traefik_task_exec_role_arn" {
   description = "ECS Task exec role ARN"
-  value       = "${module.traefik.task_exec_role_arn}"
+  value       = module.traefik.task_exec_role_arn
 }
 
 output "traefik_task_role_name" {
   description = "ECS Task role name"
-  value       = "${module.traefik.task_role_name}"
+  value       = module.traefik.task_role_name
 }
 
 output "traefik_task_role_arn" {
   description = "ECS Task role ARN"
-  value       = "${module.traefik.task_role_arn}"
+  value       = module.traefik.task_role_arn
 }
 
 output "traefik_task_role_id" {
   description = "ECS Task role id"
-  value       = "${module.traefik.task_role_id}"
+  value       = module.traefik.task_role_id
 }
 
 output "traefik_service_security_group_id" {
   description = "Security Group ID of the ECS task"
-  value       = "${module.traefik.service_security_group_id}"
+  value       = module.traefik.service_security_group_id
 }
 
 output "traefik_task_definition_family" {
   description = "ECS task definition family"
-  value       = "${module.traefik.task_definition_family}"
+  value       = module.traefik.task_definition_family
 }
 
 output "traefik_task_definition_revision" {
   description = "ECS task definition revision"
-  value       = "${module.traefik.task_definition_revision}"
+  value       = module.traefik.task_definition_revision
 }
 
 output "traefik_scale_down_policy_arn" {
   description = "Autoscaling scale up policy ARN"
-  value       = "${module.traefik.scale_down_policy_arn}"
+  value       = module.traefik.scale_down_policy_arn
 }
 
 output "traefik_scale_up_policy_arn" {
   description = "Autoscaling scale up policy ARN"
-  value       = "${module.traefik.scale_up_policy_arn}"
+  value       = module.traefik.scale_up_policy_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -562,19 +562,19 @@ variable "alb_target_group_alarms_evaluation_periods" {
 variable "alb_target_group_alarms_alarm_actions" {
   type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state"
-  default     = [""]
+  default     = []
 }
 
 variable "alb_target_group_alarms_ok_actions" {
   type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an OK state from any other state"
-  default     = [""]
+  default     = []
 }
 
 variable "alb_target_group_alarms_insufficient_data_actions" {
   type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state"
-  default     = [""]
+  default     = []
 }
 
 variable "traefik_launch_type" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,203 +1,209 @@
 variable "namespace" {
-  type        = "string"
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
   default     = "cp"
 }
 
 variable "stage" {
-  type        = "string"
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
   default     = "prod"
 }
 
 variable "name" {
-  type        = "string"
+  type        = string
   default     = "traefik"
   description = "Solution name, e.g. 'app' or 'jenkins'"
 }
 
 variable "delimiter" {
-  type        = "string"
+  type        = string
   default     = "-"
   description = "Delimiter to be used between `namespace`, `name`, `stage` and `attributes`"
 }
 
 variable "attributes" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "Additional attributes, e.g. `1`"
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map(string)
   default     = {}
   description = "Additional tags (e.g. `map(`BusinessUnit`,`XYZ`)"
 }
 
 variable "vpc_cidr_block" {
-  type        = "string"
+  type        = string
   default     = "10.10.0.0/16"
   description = "VPC CIDR block"
 }
 
 variable "vpc_availability_zones" {
-  type        = "list"
+  type        = list(string)
   description = "List of Availability Zones where subnets will be created"
 }
 
 variable "vpc_nat_gateway_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Flag to enable/disable NAT Gateways to allow servers in the private subnets to access the Internet"
 }
 
 variable "vpc_nat_instance_enabled" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Flag to enable/disable NAT Instances to allow servers in the private subnets to access the Internet"
 }
 
 variable "vpc_nat_instance_type" {
-  type        = "string"
+  type        = string
   default     = "t3.micro"
   description = "NAT Instance type"
 }
 
 variable "vpc_map_public_ip_on_launch" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Instances launched into a public subnet should be assigned a public IP address"
 }
 
 variable "vpc_max_subnet_count" {
-  type        = "string"
-  default     = "0"
+  type        = number
+  default     = 0
   description = "Sets the maximum amount of subnets to deploy. 0 will deploy a subnet for every provided availablility zone (in availability_zones variable) within the region"
 }
 
 variable "ec2_asg_enabled" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Defines whether autoscaling EC2 instance group should be provisioned for a ECS cluster"
 }
 
 variable "ec2_asg_instance_type" {
-  type        = "string"
+  type        = string
   description = "Instance type to launch"
   default     = "t3.micro"
 }
 
 variable "ec2_asg_instance_initiated_shutdown_behavior" {
-  type        = "string"
+  type        = string
   description = "Shutdown behavior for the instances in ASG. Can be `stop` or `terminate`"
   default     = "terminate"
 }
 
 variable "ec2_asg_key_name" {
-  type        = "string"
+  type        = string
   description = "The SSH key name that should be used for the instances in ASG"
   default     = ""
 }
 
 variable "ec2_asg_security_group_ids" {
   description = "A list of security group IDs to be associated with instances in ASG"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_enable_monitoring" {
   description = "Enable/disable detailed monitoring of the instanes in ASG"
-  default     = "true"
+  default     = true
+  type        = bool
 }
 
 variable "ec2_asg_ebs_optimized" {
   description = "If true, the launched EC2 instances in ASG will be EBS-optimized"
-  default     = "false"
+  default     = false
+  type        = bool
 }
 
 variable "ec2_asg_block_device_mappings" {
   description = "Specify volumes to attach to the instance in ASG besides the volumes specified by the AMI"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_instance_market_options" {
   description = "The market (purchasing) option for the instances in ASG"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_placement" {
   description = "The placement specifications of the instances in ASG"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_credit_specification" {
   description = "Customize the credit specification of the instances in ASG"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_elastic_gpu_specifications" {
   description = "Specifications of Elastic GPU to attach to the instances in ASG"
-  type        = "list"
+  type        = list(string)
   default     = []
 }
 
 variable "ec2_asg_disable_api_termination" {
   description = "If `true`, enables EC2 Instance Termination Protection for instances in ASG"
-  default     = "false"
+  default     = false
+  type        = bool
 }
 
 variable "ec2_asg_default_cooldown" {
   description = "The amount of time, in seconds, after a scaling activity completes before another scaling activity can start"
-  default     = "300"
+  default     = 300
+  type        = number
 }
 
 variable "ec2_asg_health_check_grace_period" {
   description = "Time (in seconds) after instance comes into service before checking health"
-  default     = "300"
+  default     = 300
+  type        = number
 }
 
 variable "ec2_asg_health_check_type" {
-  type        = "string"
+  type        = string
   description = "Controls how health checking is done. Valid values are `EC2` or `ELB`"
   default     = "EC2"
 }
 
 variable "ec2_asg_force_delete" {
   description = "Allows deleting the autoscaling group without waiting for all instances in the pool to terminate. You can force an autoscaling group to delete even if it's in the process of scaling a resource. Normally, Terraform drains all the instances before deleting the group. This bypasses that behavior and potentially leaves resources dangling"
-  default     = "false"
+  default     = false
+  type        = bool
 }
 
 variable "ec2_asg_termination_policies" {
   description = "A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`"
-  type        = "list"
+  type        = list(string)
   default     = ["Default"]
 }
 
 variable "ec2_asg_suspended_processes" {
-  type        = "list"
+  type        = list(string)
   description = "A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`. Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly."
   default     = []
 }
 
 variable "ec2_asg_placement_group" {
-  type        = "string"
+  type        = string
   description = "The name of the placement group into which you'll launch your instances, if any"
   default     = ""
 }
 
 variable "ec2_asg_metrics_granularity" {
-  type        = "string"
+  type        = string
   description = "The granularity to associate with the metrics to collect. The only valid value is 1Minute"
   default     = "1Minute"
 }
 
 variable "ec2_asg_enabled_metrics" {
   description = "A list of metrics to collect. The allowed values are `GroupMinSize`, `GroupMaxSize`, `GroupDesiredCapacity`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupTerminatingInstances`, `GroupTotalInstances`"
-  type        = "list"
+  type        = list(string)
 
   default = [
     "GroupMinSize",
@@ -212,196 +218,199 @@ variable "ec2_asg_enabled_metrics" {
 }
 
 variable "ec2_asg_wait_for_capacity_timeout" {
-  type        = "string"
+  type        = string
   description = "A maximum duration that Terraform should wait for ASG instances to be healthy before timing out. Setting this to '0' causes Terraform to skip all Capacity Waiting behavior"
   default     = "10m"
 }
 
 variable "ec2_asg_protect_from_scale_in" {
   description = "Allows setting instance protection. The autoscaling group will not select instances with this setting for terminination during scale in events"
-  default     = "false"
+  default     = false
+  type        = bool
 }
 
 variable "ec2_asg_service_linked_role_arn" {
-  type        = "string"
+  type        = string
   description = "The ARN of the service-linked role that the ASG will use to call other AWS services"
   default     = ""
 }
 
 variable "ec2_asg_autoscaling_policies_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Whether to create `aws_autoscaling_policy` and `aws_cloudwatch_metric_alarm` resources to control Auto Scaling"
 }
 
 variable "ec2_asg_autoscaling_min_capacity" {
-  type        = "string"
+  type        = number
   description = "Minimum number of running EC2 instances in ASG"
-  default     = "2"
+  default     = 2
 }
 
 variable "ec2_asg_autoscaling_max_capacity" {
-  type        = "string"
+  type        = number
   description = "Maximum number of running EC2 instances in ASG"
-  default     = "3"
+  default     = 3
 }
 
 variable "ec2_asg_autoscaling_scale_up_cooldown_seconds" {
-  type        = "string"
-  default     = "300"
+  type        = number
+  default     = 300
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
 
 variable "ec2_asg_autoscaling_scale_up_scaling_adjustment" {
+  type        = number
   default     = 1
   description = "The number of instances by which to scale. `scale_up_adjustment_type` determines the interpretation of this number (e.g. as an absolute number or as a percentage of the existing Auto Scaling group size). A positive increment adds to the current capacity and a negative value removes from the current capacity"
 }
 
 variable "ec2_asg_autoscaling_scale_up_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "ec2_asg_autoscaling_scale_up_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "ec2_asg_autoscaling_scale_down_cooldown_seconds" {
-  type        = "string"
-  default     = "300"
+  type        = number
+  default     = 300
   description = "The amount of time, in seconds, after a scaling activity completes and before the next scaling activity can start"
 }
 
 variable "ec2_asg_autoscaling_scale_down_scaling_adjustment" {
+  type        = number
   default     = -1
   description = "The number of instances by which to scale. `scale_down_scaling_adjustment` determines the interpretation of this number (e.g. as an absolute number or as a percentage of the existing Auto Scaling group size). A positive increment adds to the current capacity and a negative value removes from the current capacity"
 }
 
 variable "ec2_asg_autoscaling_scale_down_adjustment_type" {
-  type        = "string"
+  type        = string
   default     = "ChangeInCapacity"
   description = "Specifies whether the adjustment is an absolute number or a percentage of the current capacity. Valid values are `ChangeInCapacity`, `ExactCapacity` and `PercentChangeInCapacity`"
 }
 
 variable "ec2_asg_autoscaling_scale_down_policy_type" {
-  type        = "string"
+  type        = string
   default     = "SimpleScaling"
   description = "The scalling policy type, either `SimpleScaling`, `StepScaling` or `TargetTrackingScaling`"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_high_evaluation_periods" {
-  type        = "string"
-  default     = "2"
+  type        = number
+  default     = 2
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_high_period_seconds" {
-  type        = "string"
-  default     = "300"
+  type        = number
+  default     = 300
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_high_threshold_percent" {
-  type        = "string"
-  default     = "90"
+  type        = number
+  default     = 90
   description = "The value against which the specified statistic is compared"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_high_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_low_evaluation_periods" {
-  type        = "string"
-  default     = "2"
+  type        = number
+  default     = 2
   description = "The number of periods over which data is compared to the specified threshold"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_low_period_seconds" {
-  type        = "string"
-  default     = "300"
+  type        = number
+  default     = 300
   description = "The period in seconds over which the specified statistic is applied"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_low_threshold_percent" {
-  type        = "string"
-  default     = "10"
+  type        = number
+  default     = 10
   description = "The value against which the specified statistic is compared"
 }
 
 variable "ec2_asg_autoscaling_cpu_utilization_low_statistic" {
-  type        = "string"
+  type        = string
   default     = "Average"
   description = "The statistic to apply to the alarm's associated metric. Either of the following is supported: `SampleCount`, `Average`, `Sum`, `Minimum`, `Maximum`"
 }
 
 variable "ecs_disable_privilegged_mode" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Defines whether privilegged mode should be disabed for containers running with launch type EC2"
 }
 
 variable "alb_security_group_ids" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "A list of additional security group IDs to allow access to ALB"
 }
 
 variable "alb_http_port" {
-  type        = "string"
-  default     = "80"
+  type        = number
+  default     = 80
   description = "The port for the HTTP listener"
 }
 
 variable "alb_http_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "A boolean flag to enable/disable HTTP listener"
 }
 
 variable "alb_http_ingress_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "List of CIDR blocks to allow in HTTP security group"
 }
 
 variable "alb_http_ingress_prefix_list_ids" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of prefix list IDs for allowing access to HTTP ingress security group"
 }
 
 variable "alb_certificate_arn" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The ARN of the default SSL certificate for HTTPS listener"
 }
 
 variable "alb_https_port" {
-  type        = "string"
-  default     = "443"
+  type        = number
+  default     = 443
   description = "The port for the HTTPS listener"
 }
 
 variable "alb_https_enabled" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "A boolean flag to enable/disable HTTPS listener"
 }
 
 variable "alb_https_ingress_cidr_blocks" {
-  type        = "list"
+  type        = list(string)
   default     = ["0.0.0.0/0"]
   description = "List of CIDR blocks to allow in HTTPS security group"
 }
 
 variable "alb_https_ingress_prefix_list_ids" {
-  type        = "list"
+  type        = list(string)
   default     = []
   description = "List of prefix list IDs for allowing access to HTTPS ingress security group"
 }
@@ -412,37 +421,37 @@ variable "alb_https_ssl_policy" {
 }
 
 variable "alb_http_to_https_redirect_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Defines whether HTTP traffic should be redirected to HTTPS on ALB"
 }
 
 variable "alb_http_to_https_redirect_permanent" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Defines whether HTTP to HTTPS redirect on ALB should be permanent (i.e. return 301 or 302 HTTP code)."
 }
 
 variable "alb_http2_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "A boolean flag to enable/disable HTTP/2"
 }
 
 variable "alb_access_logs_prefix" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The S3 bucket prefix"
 }
 
 variable "alb_access_logs_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "A boolean flag to enable/disable access_logs"
 }
 
 variable "alb_access_logs_region" {
-  type        = "string"
+  type        = string
   default     = "us-east-1"
   description = "The region for the access_logs S3 bucket"
 }
@@ -450,178 +459,179 @@ variable "alb_access_logs_region" {
 variable "alb_access_logs_s3_bucket_force_destroy" {
   description = "A boolean that indicates all objects should be deleted from the ALB access logs S3 bucket so that the bucket can be destroyed without error"
   default     = false
+  type        = bool
 }
 
 variable "alb_idle_timeout" {
-  type        = "string"
-  default     = "60"
+  type        = number
+  default     = 60
   description = "The time in seconds that the connection is allowed to be idle"
 }
 
 variable "alb_deletion_protection_enabled" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "A boolean flag to enable/disable deletion protection for ALB"
 }
 
 variable "alb_target_group_alarms_enabled" {
-  type        = "string"
+  type        = bool
   description = "A boolean to enable/disable CloudWatch Alarms for ALB Target metrics"
-  default     = "false"
+  default     = false
 }
 
 variable "alb_target_group_alarms_3xx_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum number of 3XX HTTPCodes in a given period for ECS Service"
-  default     = "25"
+  default     = 25
 }
 
 variable "alb_target_group_alarms_4xx_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum number of 4XX HTTPCodes in a given period for ECS Service"
-  default     = "25"
+  default     = 25
 }
 
 variable "alb_target_group_alarms_5xx_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum number of 5XX HTTPCodes in a given period for ECS Service"
-  default     = "25"
+  default     = 25
 }
 
 variable "alb_target_group_alarms_response_time_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum ALB Target Group response time"
-  default     = "0.5"
+  default     = 0.5
 }
 
 variable "alb_target_group_alarms_period" {
-  type        = "string"
+  type        = number
   description = "The period (in seconds) to analyze for ALB CloudWatch Alarms"
-  default     = "300"
+  default     = 300
 }
 
 variable "alb_target_group_alarms_evaluation_periods" {
-  type        = "string"
+  type        = number
   description = "The number of periods to analyze for ALB CloudWatch Alarms"
-  default     = "1"
+  default     = 1
 }
 
 variable "alb_target_group_alarms_alarm_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an ALARM state from any other state"
   default     = []
 }
 
 variable "alb_target_group_alarms_ok_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an OK state from any other state"
   default     = []
 }
 
 variable "alb_target_group_alarms_insufficient_data_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to execute when ALB Target Group alarms transition into an INSUFFICIENT_DATA state from any other state"
   default     = []
 }
 
 variable "traefik_launch_type" {
-  type        = "string"
+  type        = string
   description = "The launch type on which to run your service. Valid values are `EC2` and `FARGATE`"
   default     = "FARGATE"
 }
 
 variable "traefik_assign_public_ip" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Assign a public IP address to the ENI (Fargate launch type only). Valid values are true or false. Default false."
 }
 
 variable "traefik_container_name" {
-  type        = "string"
+  type        = string
   default     = "traefik"
   description = "The name of the container in task definition to associate with the load balancer"
 }
 
 variable "traefik_container_http_port" {
-  type        = "string"
-  default     = "80"
+  type        = number
+  default     = 80
   description = "Port at which Traefik will accept traffic from ALB"
 }
 
 variable "traefik_task_image" {
-  type        = "string"
+  type        = string
   default     = "library/traefik:1.7"
   description = "Traefik image"
 }
 
 variable "traefik_task_cpu" {
-  type        = "string"
+  type        = number
   description = "The vCPU setting to control cpu limits of traefik container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
-  default     = "256"
+  default     = 256
 }
 
 variable "traefik_task_memory" {
-  type        = "string"
+  type        = number
   description = "The amount of RAM to allow traefik container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"
-  default     = "512"
+  default     = 512
 }
 
 variable "traefik_task_memory_reservation" {
-  type        = "string"
+  type        = number
   description = "The amount of RAM (Soft Limit) to allow traefik container to use in MB. This value must be less than container_memory if set"
-  default     = "128"
+  default     = 128
 }
 
 variable "traefik_log_level" {
-  type        = "string"
+  type        = string
   default     = "INFO"
   description = "Traefk log level. See https://docs.traefik.io/configuration/logs/"
 }
 
 variable "traefik_log_format" {
-  type        = "string"
+  type        = string
   default     = "common"
   description = "Traefk log format. See https://docs.traefik.io/configuration/logs/"
 }
 
 variable "traefik_logs_retention" {
-  type        = "string"
-  default     = "30"
+  type        = number
+  default     = 30
   description = "Defines retention period in days for Traefik logs in Cloudwatch"
 }
 
 variable "traefik_logs_region" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "AWS region for storing Cloudwatch logs from traefik container. Defaults to the same as ECS Cluster region."
 }
 
 variable "traefik_dashboard_enabled" {
-  type        = "string"
-  default     = "false"
+  type        = bool
+  default     = false
   description = "Defines whether traefik dashboard is enabled"
 }
 
 variable "traefik_dashboard_host" {
-  type        = "string"
+  type        = string
   default     = "dashboard.example.com"
   description = "Traefik dashboard host at which API should be exposed"
 }
 
 variable "traefik_dashboard_basic_auth_enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Defines whther basic auth is enabled for Traefik dashboard or not"
 }
 
 variable "traefik_dashboard_basic_auth_user" {
-  type        = "string"
+  type        = string
   default     = "admin"
   description = "Basic auth username for Traefik dashboard"
 }
 
 variable "traefik_dashboard_basic_auth_password" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "Basic auth password for Traefik dashboard. If left empty, a random one will be generated."
 }
@@ -629,28 +639,31 @@ variable "traefik_dashboard_basic_auth_password" {
 variable "traefik_desired_count" {
   description = "The number of instances of the task definition to place and keep running"
   default     = 1
+  type        = number
 }
 
 variable "traefik_deployment_controller_type" {
   description = "Type of deployment controller. Valid values: `CODE_DEPLOY`, `ECS`."
   default     = "ECS"
+  type        = string
 }
 
 variable "traefik_deployment_maximum_percent" {
   description = "The upper limit of the number of tasks (as a percentage of `desired_count`) that can be running in a service during a deployment"
   default     = 200
+  type        = number
 }
 
 variable "traefik_deployment_minimum_healthy_percent" {
   description = "The lower limit (as a percentage of `desired_count`) of the number of tasks that must remain running and healthy in a service during a deployment"
   default     = 100
+  type        = number
 }
 
 variable "traefik_mount_points" {
-  type        = "list"
+  type        = list(string)
   description = "Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume`"
   default     = []
-
   #default     = [
   #  {
   #    containerPath  = "/tmp"
@@ -660,187 +673,187 @@ variable "traefik_mount_points" {
 }
 
 variable "traefik_volumes" {
-  type        = "list"
+  type        = list(string)
   description = "Task volume definitions as list of maps"
   default     = []
 }
 
 variable "traefik_ignore_changes_task_definition" {
-  type        = "string"
+  type        = bool
   description = "Whether to ignore changes in container definition and task definition in the ECS service"
-  default     = "true"
+  default     = true
 }
 
 variable "traefik_autoscaling_enabled" {
-  type        = "string"
+  type        = bool
   description = "A boolean to enable/disable Autoscaling policy for ECS Service"
-  default     = "false"
+  default     = false
 }
 
 variable "traefik_autoscaling_dimension" {
-  type        = "string"
+  type        = string
   description = "Dimension to autoscale on (valid options: cpu, memory)"
   default     = "memory"
 }
 
 variable "traefik_autoscaling_min_capacity" {
-  type        = "string"
+  type        = number
   description = "Minimum number of running instances of a Service"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_autoscaling_max_capacity" {
-  type        = "string"
+  type        = number
   description = "Maximum number of running instances of a Service"
-  default     = "2"
+  default     = 2
 }
 
 variable "traefik_autoscaling_scale_up_adjustment" {
-  type        = "string"
+  type        = number
   description = "Scaling adjustment to make during scale up event"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_autoscaling_scale_up_cooldown" {
-  type        = "string"
+  type        = number
   description = "Period (in seconds) to wait between scale up events"
-  default     = "60"
+  default     = 60
 }
 
 variable "traefik_autoscaling_scale_down_adjustment" {
-  type        = "string"
+  type        = number
   description = "Scaling adjustment to make during scale down event"
-  default     = "-1"
+  default     = -1
 }
 
 variable "traefik_autoscaling_scale_down_cooldown" {
-  type        = "string"
+  type        = number
   description = "Period (in seconds) to wait between scale down events"
-  default     = "300"
+  default     = 300
 }
 
 variable "traefik_ecs_alarms_enabled" {
-  type        = "string"
+  type        = bool
   description = "A boolean to enable/disable CloudWatch Alarms for ECS Service metrics"
-  default     = "false"
+  default     = false
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_high_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum percentage of CPU utilization average"
-  default     = "80"
+  default     = 80
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_high_evaluation_periods" {
-  type        = "string"
+  type        = number
   description = "Number of periods to evaluate for the alarm"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_high_period" {
-  type        = "string"
+  type        = number
   description = "Duration in seconds to evaluate for the alarm"
-  default     = "300"
+  default     = 300
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_high_alarm_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on CPU Utilization High Alarm action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_high_ok_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on CPU Utilization High OK action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_low_threshold" {
-  type        = "string"
+  type        = number
   description = "The minimum percentage of CPU utilization average"
-  default     = "20"
+  default     = 20
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_low_evaluation_periods" {
-  type        = "string"
+  type        = number
   description = "Number of periods to evaluate for the alarm"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_low_period" {
-  type        = "string"
+  type        = number
   description = "Duration in seconds to evaluate for the alarm"
-  default     = "300"
+  default     = 300
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_low_alarm_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on CPU Utilization Low Alarm action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_cpu_utilization_low_ok_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on CPU Utilization Low OK action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_memory_utilization_high_threshold" {
-  type        = "string"
+  type        = number
   description = "The maximum percentage of Memory utilization average"
-  default     = "80"
+  default     = 80
 }
 
 variable "traefik_ecs_alarms_memory_utilization_high_evaluation_periods" {
-  type        = "string"
+  type        = number
   description = "Number of periods to evaluate for the alarm"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_ecs_alarms_memory_utilization_high_period" {
-  type        = "string"
+  type        = number
   description = "Duration in seconds to evaluate for the alarm"
-  default     = "300"
+  default     = 300
 }
 
 variable "traefik_ecs_alarms_memory_utilization_high_alarm_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on Memory Utilization High Alarm action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_memory_utilization_high_ok_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on Memory Utilization High OK action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_memory_utilization_low_threshold" {
-  type        = "string"
+  type        = number
   description = "The minimum percentage of Memory utilization average"
-  default     = "20"
+  default     = 20
 }
 
 variable "traefik_ecs_alarms_memory_utilization_low_evaluation_periods" {
-  type        = "string"
+  type        = number
   description = "Number of periods to evaluate for the alarm"
-  default     = "1"
+  default     = 1
 }
 
 variable "traefik_ecs_alarms_memory_utilization_low_period" {
-  type        = "string"
+  type        = number
   description = "Duration in seconds to evaluate for the alarm"
-  default     = "300"
+  default     = 300
 }
 
 variable "traefik_ecs_alarms_memory_utilization_low_alarm_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on Memory Utilization Low Alarm action"
   default     = []
 }
 
 variable "traefik_ecs_alarms_memory_utilization_low_ok_actions" {
-  type        = "list"
+  type        = list(string)
   description = "A list of ARNs (i.e. SNS Topic ARN) to notify on Memory Utilization Low OK action"
   default     = []
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = "~> 0.12.0"
+
+  required_providers {
+    aws   = "~> 2.12"
+    local = "~> 1.2"
+  }
+}


### PR DESCRIPTION
**What**
- Port module to Terraform 0.12
- Pin all providers
- Update README

**Why**
- Module currently does not work with 0.12. Much easier syntax

**TODOs**:
- Fix the issue described here: https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms/pull/18